### PR TITLE
[4a45Cfas] add try-it buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,7 +36,7 @@ form input {
   border: 1px solid #ccc;
   background: white;
 }
-form button {
+button {
   font-size: 14px;
   font-weight: bold;
   padding: 12px;
@@ -46,12 +46,15 @@ form button {
   text-transform: uppercase;
 
 }
-form button + button {
+button + button {
   margin-left: 12px;
 }
-form button:hover,
-form button:active {
+button:hover,
+button:active {
   background: #ddd;
+}
+.result button {
+  margin-top: 12px;
 }
 pre {
   display: block;
@@ -59,4 +62,10 @@ pre {
   padding: 24px;
   word-wrap: break-word;
   white-space: pre-wrap;
+}
+pre.success {
+  background: #f3f3bb;
+}
+pre.error {
+  background: #f3bbbb;
 }

--- a/index.html
+++ b/index.html
@@ -39,18 +39,23 @@
     <section id="results">
       <h2>Results</h2>
       <div>
+        <h3>Endpoint</h3>
+        <pre id="results-resource"></pre>
+      </div>
+
+      <div>
         <h3>Query String</h3>
         <pre id="results-query"></pre>
       </div>
 
-      <div>
+      <div class="api-call">
         <h3>API Url</h3>
-        <pre id="results-url"></pre>
+        <pre id="results-url" contenteditable="true"></pre>
       </div>
 
-      <div>
+      <div class="api-call">
         <h3>JSON payload</h3>
-        <pre id="results-payload"></pre>
+        <pre id="results-payload" contenteditable="true"></pre>
       </div>
     </section>
   </main>


### PR DESCRIPTION
https://trello.com/c/4a45Cfas/811-add-try-it-buttons-to-search-converter

This is very closely based on the 'try it' buttons from the api documentation - @orakili if you have any suggestions for improvements I can add them to the documentation too. (I'll borrow some style choices from the search converter when removing Bootstrap from the documentation.)

 This adds an 'endpoint' field too, which may be useful, and buttons for copying the text. (These may be useful to show whenever the 'API Url' or 'JSON payload' fields are populated.)